### PR TITLE
Fix for issue - TCF API `removeEventListener` command returns `null`

### DIFF
--- a/modules/cmpapi/src/CallResponder.ts
+++ b/modules/cmpapi/src/CallResponder.ts
@@ -51,7 +51,6 @@ export class CallResponder {
       if (customCommands?.[TCFCommand.GET_TC_DATA]) {
 
         customCommands[TCFCommand.ADD_EVENT_LISTENER] = customCommands[TCFCommand.GET_TC_DATA];
-        customCommands[TCFCommand.REMOVE_EVENT_LISTENER] = customCommands[TCFCommand.GET_TC_DATA];
 
       }
 

--- a/modules/cmpapi/test/CallResponder.test.ts
+++ b/modules/cmpapi/test/CallResponder.test.ts
@@ -95,7 +95,7 @@ describe('CallResponder', (): void => {
 
   });
 
-  it('should use custom "getTCData" command handler for "addEventListener" and "removeEventListener" commands', (): void => {
+  it('should use custom "getTCData" command handler for "addEventListener" command', (): void => {
 
     const customCommandCallback = sinon.stub();
 
@@ -117,9 +117,37 @@ describe('CallResponder', (): void => {
     callResponder.apiCall(TCFCommand.ADD_EVENT_LISTENER, null, () => undefined);
     expect(customCommandCallback.callCount).to.eql(2);
 
-    // Invoke `removeEventListener` command and make sure custom callback was called
-    callResponder.apiCall(TCFCommand.REMOVE_EVENT_LISTENER, null, () => undefined);
-    expect(customCommandCallback.callCount).to.eql(3);
+  });
+
+  it('should "addEventListener" and "removeEventListener" methods behave properly', (): void => {
+
+    const customCommandCallback = sinon.stub();
+    const callResponder = new CallResponder({
+      [TCFCommand.GET_TC_DATA]: (): void => {
+
+        customCommandCallback();
+
+      },
+    });
+    callResponder.apiCall(TCFCommand.ADD_EVENT_LISTENER, null, () => undefined);
+    // remove listener id == 0 first time should produce success == true
+    callResponder.apiCall(TCFCommand.REMOVE_EVENT_LISTENER, null, (success: boolean) => {
+
+      expect(success).to.be.true;
+
+    }, 0);
+    // remove listener id == 0 second time should produce success == false
+    callResponder.apiCall(TCFCommand.REMOVE_EVENT_LISTENER, null, (success: boolean) => {
+
+      expect(success).to.be.false;
+
+    }, 0);
+    // remove listener id == 1 should produce success == false because it is not added yet
+    callResponder.apiCall(TCFCommand.REMOVE_EVENT_LISTENER, null, (success: boolean) => {
+
+      expect(success).to.be.false;
+
+    }, 1);
 
   });
 


### PR DESCRIPTION
### Issue description
Call to TCF API `removeEventListener` command returns `null` as the first argument for the  callback function when called with `listenerId` that was previously returned by `addEventListener` and not removed yet. 

Expected result:  `true`

[Documentation](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#removeeventlistener)
### Steps to reproduce

1.  On website running TCF API define callback function: 

    `const cb = (tcData, success) => { console.log(tcData); console.log(success); };`

2. Add Event Listener using `addEventListener`  TCF API command, see [documentation](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#addeventlistener): 

   `let res = __tcfapi('addEventListener', 2, cb);`

3. Check console log printout (`tcData`) to see `listenerId` value. Suppose the `listenerId === 0`;

4. Call `RemoveEventListener` TCF API command for `listenerId` as the last argument. We have `listenerId === 0` in this example: 

    `__tcfapi('removeEventListener',2,cb,0);`

5. Expected result (console log from `cb` callback function): 

    `true` 
    `true`

6. Actual result (console log from `cb` callback function): 

   `null` 
   `false`

### Proposed solution 
Remove the following line ([#54](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/blob/81d39d2df895bb567a096c733f07cf5f73bac974/modules/cmpapi/src/CallResponder.ts#L54)) from `CallResponder.ts`:

    `customCommands[TCFCommand.REMOVE_EVENT_LISTENER] = customCommands[TCFCommand.GET_TC_DATA];`

### Testing
The original TCF API library passes the unit test for `RemoveEventListenerCommand` class and for `CallResponder` class but api call for `removeEventListener` is tested only for the following assertion:
  "Invoke `removeEventListener` command and make sure custom callback was called"

The changes includes new tests to check if `removeEventListener` API call works properly 

