### PR TITLE
Implement `toArray` method in the core `Vector` class to support prototype.js `Array.from` overload 

### DIFF
--- a/modules/cli/package.json
+++ b/modules/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-cli",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Decode a iab TCF (Transparency and Consent Framework) TC String via the command line",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",
@@ -27,7 +27,7 @@
     "lint": "eslint `find src -name '*.ts'`"
   },
   "dependencies": {
-    "@didomi/iabtcf-core": "1.5.3"
+    "@didomi/iabtcf-core": "1.5.4"
   },
   "devDependencies": {
     "@types/node": "^17.0.18",

--- a/modules/cmpapi/package.json
+++ b/modules/cmpapi/package.json
@@ -64,7 +64,8 @@
     "lib"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@didomi:registry": "https://registry.npmjs.org/"
   },
   "keywords": [
     "interactive",

--- a/modules/cmpapi/package.json
+++ b/modules/cmpapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-cmpapi",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Ensures other in-page digital marketing technologies have access to CMP transparency and consent information for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",
@@ -31,8 +31,8 @@
     "@didomi/iabtcf-core": ">=1.0.0"
   },
   "devDependencies": {
-    "@didomi/iabtcf-stub": "1.5.3",
-    "@didomi/iabtcf-testing": "1.5.3",
+    "@didomi/iabtcf-stub": "1.5.4",
+    "@didomi/iabtcf-testing": "1.5.4",
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/mocha": "^9.1.0",
     "@types/sinon": "10.0.11",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-core",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Ensures consistent encoding and decoding of TC Signals for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",
@@ -28,7 +28,7 @@
     "test-cov": "rm -rf coverage; nyc --reporter=html mocha"
   },
   "devDependencies": {
-    "@didomi/iabtcf-testing": "1.5.3",
+    "@didomi/iabtcf-testing": "1.5.4",
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "3.2.8",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -58,7 +58,8 @@
     "lib"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "@didomi:registry": "https://registry.npmjs.org/"
   },
   "keywords": [
     "interactive",

--- a/modules/core/src/model/Vector.ts
+++ b/modules/core/src/model/Vector.ts
@@ -28,6 +28,20 @@ export class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
 
   }
 
+  public toArray(): Array<IdBoolTuple> {
+
+    const result = new Array<IdBoolTuple>(0);
+
+    for (let i = 1; i <= this.maxId; i++) {
+
+      result.push([i, this.has(i)] as IdBoolTuple);
+
+    }
+
+    return result;
+
+  }
+
   /**
    * values()
    *

--- a/modules/core/src/model/Vector.ts
+++ b/modules/core/src/model/Vector.ts
@@ -28,6 +28,12 @@ export class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
 
   }
 
+  /**
+   * toArray()
+   *
+   * @return {Array<IdBoolTuple>} returns an array of all values in the set
+   *
+   */
   public toArray(): Array<IdBoolTuple> {
 
     const result = new Array<IdBoolTuple>(0);

--- a/modules/core/test/model/Vector.test.ts
+++ b/modules/core/test/model/Vector.test.ts
@@ -123,6 +123,33 @@ export function run(): void {
 
     });
 
+    it('toArray - construct array with id/bool tuples', (): void => {
+
+      const idAr: number[] = [1, 3, 5, 7, 9, 12, 15];
+      const vector: Vector = new Vector();
+
+      vector.set(idAr);
+
+      expect(vector.toArray()).to.deep.equal([
+        [1, true],
+        [2, false],
+        [3, true],
+        [4, false],
+        [5, true],
+        [6, false],
+        [7, true],
+        [8, false],
+        [9, true],
+        [10, false],
+        [11, false],
+        [12, true],
+        [13, false],
+        [14, false],
+        [15, true],
+      ]);
+
+    });
+
   });
 
 }

--- a/modules/stub/package.json
+++ b/modules/stub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-stub",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "CMP API Stub code",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",

--- a/modules/testing/package.json
+++ b/modules/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-testing",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Shared testing utilities",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iabtcf",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Official compliant tool suite for implementing the iab. Transparency and Consent Framework (TCF).",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
The lates version on IAB TCF library is not working well with _prototype.js_ library that some of our clients are still using. 

The issue is  `Array.from` function that _prototype.js_ is overloading with there following code
```javascript
function $A(iterable) {
  if (!iterable) return [];
  if ('toArray' in Object(iterable)) return iterable.toArray();
  var length = iterable.length || 0, results = new Array(length);
  while (length--) results[length] = iterable[length];
  return results;
}
Array.from = $A;
```
In this case  the core library `Vector` class object produce the empty array in `createVectorField` method of `TCData` class
```typescript
return [...vector].reduce<BooleanVector>((booleanVector, keys: IdBoolTuple): BooleanVector => {

      booleanVector[keys[0].toString(10)] = keys[1];
      return booleanVector;

}, {});
```
Because the core `Vector` class does not have `toArray` and `length` properties the expression `[...vector]` that will call `Array.from` function with `prototype.js` code will always produce empty array
```javascript
[...vector] -> Array.from(vector) -> []
```
The solution that this PR is implementing is to introduce  `toArray` public method in `Vector` class in IAB TCF core library 
```typescript
public toArray(): Array<IdBoolTuple> {

    const result = new Array<IdBoolTuple>(0);

    for (let i = 1; i <= this.maxId; i++) {

      result.push([i, this.has(i)] as IdBoolTuple);

    }
    return result;
}
```
